### PR TITLE
Fix NumPy compatibility and update LangChain dependencies

### DIFF
--- a/create_database.py
+++ b/create_database.py
@@ -4,7 +4,7 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.schema import Document
 # from langchain.embeddings import OpenAIEmbeddings
 from langchain_openai import OpenAIEmbeddings
-from langchain_community.vectorstores import Chroma
+from langchain_chroma import Chroma
 import openai 
 from dotenv import load_dotenv
 import os
@@ -63,7 +63,6 @@ def save_to_chroma(chunks: list[Document]):
     db = Chroma.from_documents(
         chunks, OpenAIEmbeddings(), persist_directory=CHROMA_PATH
     )
-    db.persist()
     print(f"Saved {len(chunks)} chunks to {CHROMA_PATH}.")
 
 

--- a/query_data.py
+++ b/query_data.py
@@ -1,6 +1,6 @@
 import argparse
 # from dataclasses import dataclass
-from langchain_community.vectorstores import Chroma
+from langchain_chroma import Chroma
 from langchain_openai import OpenAIEmbeddings
 from langchain_openai import ChatOpenAI
 from langchain.prompts import ChatPromptTemplate
@@ -41,7 +41,7 @@ def main():
     print(prompt)
 
     model = ChatOpenAI()
-    response_text = model.predict(prompt)
+    response_text = model.invoke(prompt).content
 
     sources = [doc.metadata.get("source", None) for doc, _score in results]
     formatted_response = f"Response: {response_text}\nSources: {sources}"


### PR DESCRIPTION
- Fix NumPy 2.0 compatibility by upgrading ChromaDB from 0.5.0 to 1.0.16
- Update Chroma imports to use new langchain-chroma package
- Replace deprecated model.predict() with model.invoke().content
- Remove deprecated db.persist() method call
- All deprecation warnings resolved