### PR TITLE
Update requirements.txt with current package versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,17 @@
-python-dotenv==1.0.1 # For reading environment variables stored in .env file
-langchain==0.2.2
-langchain-community==0.2.3
-langchain-openai==0.1.8 # For embeddings
-unstructured==0.14.4 # Document loading
+python-dotenv==1.1.1 # For reading environment variables stored in .env file
+langchain==0.3.27
+langchain-community==0.3.27
+langchain-core==0.3.74
+langchain-openai==0.3.30 # For embeddings
+langchain-chroma==0.2.5 # New dedicated ChromaDB package
+langchain-text-splitters==0.3.9
+unstructured==0.18.11 # Document loading
 # onnxruntime==1.17.1 # chromadb dependency: on Mac use `conda install onnxruntime -c conda-forge`
 # For Windows users, install Microsoft Visual C++ Build Tools first
 # install onnxruntime before installing `chromadb`
-chromadb==0.5.0 # Vector storage
-openai==1.31.1 # For embeddings
-tiktoken==0.7.0  # For embeddings 
+chromadb==1.0.16 # Vector storage (updated for NumPy 2.0+ compatibility)
+openai==1.99.9 # For embeddings
+tiktoken==0.11.0  # For embeddings
+numpy==2.1.2 # Required for compatibility
 
 # install markdown depenendies with: `pip install "unstructured[md]"` after install the requirements file. Leave this line commented out. 


### PR DESCRIPTION
- Updated all LangChain packages to latest versions (0.3.x)
- Added langchain-chroma==0.2.5 for new ChromaDB integration
- Updated chromadb to 1.0.16 for NumPy 2.0+ compatibility
- Updated OpenAI to 1.99.9
- Added numpy==2.1.2 explicitly
- All versions match currently working environment