### PR TITLE
Add RAG+n8n Lightning Path (AI-authored by GPT-5.1)

### DIFF
--- a/LIGHTNING_PATH.md
+++ b/LIGHTNING_PATH.md
@@ -1,0 +1,129 @@
+## RAG Lightning Path: n8n + LangChain + Chroma (≈ 1 hour)
+
+This guide shows you how to go from zero to a working **chat UI in n8n** that talks to a **RAG backend** built with **LangChain + Chroma + OpenAI**.
+
+You will:
+- Build a vector database from `data/books/alice_in_wonderland.md`
+- Query it from Python
+- Connect n8n’s chat UI to the RAG backend via a simple CLI
+
+---
+
+### 0. Prerequisites (≈ 5 minutes)
+
+- **Python**: 3.10+ installed
+- **Node.js**: 18.17+ installed (for n8n)
+- **OpenAI API key**
+
+From the project root:
+
+```bash
+# (Optional) create & activate a virtualenv
+pip install -r requirements.txt
+pip install "unstructured[md]"
+```
+
+Create a `.env` file in the project root:
+
+```env
+OPENAI_API_KEY=sk-...
+```
+
+---
+
+### 1. Build the vector database with LangChain + Chroma (≈ 10 minutes)
+
+The script `create_database.py` will:
+- Load markdown files from `data/books/`
+- Split them into overlapping chunks
+- Embed them with `OpenAIEmbeddings`
+- Store them in a local Chroma DB under `chroma/`
+
+Run:
+
+```bash
+python create_database.py
+```
+
+You should see output indicating how many chunks were created and saved.
+
+---
+
+### 2. Query the database from Python (≈ 10–15 minutes)
+
+You can use the existing CLI script to sanity-check that your RAG pipeline works end-to-end:
+
+```bash
+python query_data.py "How does Alice meet the Mad Hatter?"
+```
+
+This will:
+- Load the persisted Chroma DB from `chroma/`
+- Retrieve the most relevant chunks
+- Ask an OpenAI chat model to answer using only that context
+
+---
+
+### 3. Use `rag_cli.py`: a JSON-based RAG CLI for n8n (≈ 10 minutes)
+
+The file `rag_cli.py` wraps the same RAG logic but prints **exactly one JSON object** to stdout:
+
+```jsonc
+{
+  "answer": "<final answer text>",
+  "sources": ["data/books/alice_in_wonderland.md", "..."]
+}
+```
+
+Try it:
+
+```bash
+python rag_cli.py "How does Alice meet the Mad Hatter?"
+```
+
+This JSON shape is what the n8n workflow expects.
+
+---
+
+### 4. Start n8n (≈ 5 minutes)
+
+From any terminal:
+
+```bash
+npx n8n
+```
+
+Then open `http://localhost:5678` in your browser.
+
+You can also follow the more detailed options in `N8N_SETUP.md` if you prefer a global install or Docker.
+
+---
+
+### 5. Import and run the RAG chat workflow in n8n (≈ 15–20 minutes)
+
+1. In the n8n UI, click **“Import from File”**.
+2. Select `n8n_workflow.json` from this repository.
+3. Open the imported workflow and inspect the nodes:
+   - **`When chat message received`**: provides a chat UI and exposes `chatInput`.
+   - **`Execute RAG CLI`**: runs  
+     `python rag_cli.py "{{ $json.chatInput }}"`  
+     in the workflow’s working directory.
+   - **`Code in JavaScript`**: parses the JSON from `rag_cli.py` and formats:
+     - The answer
+     - The list of sources (files) used
+4. Click **“Activate”** or **“Execute Workflow”** (depending on your n8n version).
+5. Open the chat panel in the top-right, say **“hi”**, then ask something about Alice in Wonderland, e.g.:
+
+   > How does Alice meet the Mad Hatter?
+
+You should see a grounded answer plus a list of source files.
+
+---
+
+### 6. Where to go next
+
+Once this Lightning Path works end-to-end, you can:
+
+- **Swap documents**: drop your own `.md` files into `data/books/`, re-run `create_database.py`, and chat with your own docs.
+- **Turn the CLI into an API**: wrap the RAG call in a small FastAPI/Flask app and call it from n8n with an HTTP Request node instead of `Execute Command`.
+- **Add more tools/agents in n8n**: now that you have a solid RAG backbone, you can re-introduce more advanced Agent nodes and tools on top.

--- a/n8n_workflow.json
+++ b/n8n_workflow.json
@@ -1,0 +1,85 @@
+{
+  "name": "RAG Chat: n8n + LangChain + Chroma (Lightning Path)",
+  "nodes": [
+    {
+      "parameters": {
+        "options": {}
+      },
+      "id": "b24b05a7-d802-4413-bfb1-23e1e76f6203",
+      "name": "When chat message received",
+      "type": "@n8n/n8n-nodes-langchain.chatTrigger",
+      "typeVersion": 1.1,
+      "position": [260, 40],
+      "webhookId": "a889d2ae-2159-402f-b326-5f61e90f602e"
+    },
+    {
+      "parameters": {
+        "content": "## RAG Lightning Path\\n1. Start this workflow.\\n2. Open the chat (top-right) and say \"hi\".\\n3. Ask a question about Alice in Wonderland (e.g. \\\"How does Alice meet the Mad Hatter?\\").\\n\\nBackend: Python + LangChain + Chroma via `rag_cli.py`.",
+        "height": 200,
+        "width": 260
+      },
+      "id": "5592c045-6718-4c4e-9961-ce67a251b6df",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, -80]
+    },
+    {
+      "parameters": {
+        "command": "=python rag_cli.py \"{{ $json.chatInput }}\""
+      },
+      "id": "7b0e2777-c675-4428-8ef7-56e4e1ea6fe1",
+      "name": "Execute RAG CLI",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [520, 40]
+    },
+    {
+      "parameters": {
+        "jsCode": "const stdout = $input.first().json.stdout || \"\";\\nlet data;\\n\\ntry {\\n  data = JSON.parse(stdout);\\n} catch (e) {\\n  return {\\n    json: {\\n      output: \"Sorry, I could not understand the backend response.\",\\n    },\\n  };\\n}\\n\\nconst answer = data.answer || \"No answer returned.\";\\nconst sources = Array.isArray(data.sources) ? data.sources.filter(Boolean) : [];\\n\\nconst sourcesText = sources.length\\n  ? \"\\\\n\\\\n_Sources:_\\\\n\" + sources.map((s) => `- ${s}`).join(\"\\\\n\")\\n  : \"\";\\n\\nreturn {\\n  json: {\\n    output: answer + sourcesText,\\n  },\\n};"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [780, 40],
+      "id": "5aee133c-44a7-48c3-a54c-b6bf609c69d6",
+      "name": "Code in JavaScript"
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "When chat message received": {
+      "main": [
+        [
+          {
+            "node": "Execute RAG CLI",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Execute RAG CLI": {
+      "main": [
+        [
+          {
+            "node": "Code in JavaScript",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "97514e46-5bcf-4199-b3e4-6d67a43b0315",
+  "meta": {
+    "templateId": "self-building-ai-agent",
+    "templateCredsSetupCompleted": true,
+    "instanceId": "678d6cc7c8696176abf72fc993c99b40094ad864df2c0a3b83be4601316473c8"
+  },
+  "id": "0qB84Q3OPyWxGAqm",
+  "tags": []
+}

--- a/rag_cli.py
+++ b/rag_cli.py
@@ -1,0 +1,88 @@
+import argparse
+import json
+
+from langchain_chroma import Chroma
+from langchain_openai import OpenAIEmbeddings, ChatOpenAI
+from langchain.prompts import ChatPromptTemplate
+
+
+CHROMA_PATH = "chroma"
+
+PROMPT_TEMPLATE = """
+Answer the question based only on the following context:
+
+{context}
+
+---
+
+Answer the question based on the above context: {question}
+"""
+
+
+def build_rag_response(query_text: str) -> dict:
+    """
+    Run a RAG query against the local Chroma DB and return a JSON-serializable dict.
+
+    This is designed specifically to be easy for n8n to consume:
+    {
+      "answer": "<final model answer>",
+      "sources": ["path/to/source.md", ...]
+    }
+    """
+    embedding_function = OpenAIEmbeddings()
+    db = Chroma(persist_directory=CHROMA_PATH, embedding_function=embedding_function)
+
+    results = db.similarity_search_with_relevance_scores(query_text, k=3)
+
+    # If we didn't find anything useful, return a friendly fallback.
+    if len(results) == 0 or results[0][1] < 0.7:
+        return {
+            "answer": "I couldn't find anything relevant in the knowledge base for that question.",
+            "sources": [],
+        }
+
+    context_text = "\n\n---\n\n".join([doc.page_content for doc, _score in results])
+    prompt = ChatPromptTemplate.from_template(PROMPT_TEMPLATE).format(
+        context=context_text,
+        question=query_text,
+    )
+
+    # Use a deterministic model by default for more reproducible results in demos.
+    model = ChatOpenAI(temperature=0)
+    response_text = model.invoke(prompt).content
+
+    sources = [doc.metadata.get("source", None) for doc, _score in results]
+
+    return {
+        "answer": response_text,
+        "sources": sources,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Simple JSON-based RAG CLI for use with n8n. "
+            "Example: python rag_cli.py \"How does Alice meet the Mad Hatter?\""
+        )
+    )
+    parser.add_argument("query_text", type=str, help="The query text.")
+    args = parser.parse_args()
+
+    try:
+        result = build_rag_response(args.query_text)
+    except Exception as exc:  # pragma: no cover - defensive, for robust demos
+        # In teaching/learning scenarios we prefer a clear JSON error payload
+        # over a Python stack trace on stdout.
+        result = {
+            "answer": "Something went wrong while answering your question.",
+            "sources": [],
+            "error": str(exc),
+        }
+
+    # Print a single JSON object to stdout so n8n can just JSON.parse() it.
+    print(json.dumps(result, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This pull request adds a focused, 1-hour "Lightning Path" for learning how to connect n8n with a LangChain + Chroma RAG backend, and makes the existing n8n workflow easier to use as a real chat experience.

> **Note for reviewers:** This PR was authored by an AI assistant (GPT-5.1) at the explicit request of the repository owner.

---

## Changes

### 1. New JSON-based RAG CLI for n8n

- Added `rag_cli.py`:
  - Wraps the existing Chroma + LangChain + OpenAI pipeline in a small CLI.
  - Performs retrieval with `similarity_search_with_relevance_scores` against the persisted `chroma/` DB.
  - Returns a single JSON object to stdout with shape:
    - `{"answer": "<final answer>", "sources": ["path/to/source.md", ...]}`
  - Uses `ChatOpenAI(temperature=0)` for deterministic, demo-friendly outputs.
  - Includes defensive error handling to always emit a JSON payload instead of a Python stack trace, which makes it robust for n8n.

### 2. Simplified n8n workflow for RAG chat

- Replaced the previous self-building-agent style workflow in `n8n_workflow.json` with a minimal, RAG-focused flow:
  - **`When chat message received`**: LangChain chat trigger node that exposes `chatInput`.
  - **`Execute RAG CLI`**: `Execute Command` node running:
    - `python rag_cli.py "{{ $json.chatInput }}"`
  - **`Code in JavaScript`**: small JS snippet that:
    - `JSON.parse`s the CLI stdout.
    - Extracts `answer` and (optionally) `sources`.
    - Formats a final `output` string for the chat UI, including a simple sources list when available.
- Updated the workflow name to:
  - `RAG Chat: n8n + LangChain + Chroma (Lightning Path)`
- Added a `Sticky Note` node with inline instructions so learners can follow the steps directly inside n8n.

This results in an easy-to-understand, three-node chain: **Chat Trigger → Execute RAG CLI → Code → chat response**.

### 3. New documentation: `LIGHTNING_PATH.md`

- Added `LIGHTNING_PATH.md` describing a ~1 hour learning path:
  - **Step 0**: Prerequisites (Python, Node, OpenAI key) and installing dependencies.
  - **Step 1**: Building the Chroma vector DB via `create_database.py`.
  - **Step 2**: Verifying the RAG pipeline via `query_data.py`.
  - **Step 3**: Using `rag_cli.py` and understanding its JSON output shape.
  - **Step 4**: Starting n8n (`npx n8n`) and opening the local UI.
  - **Step 5**: Importing `n8n_workflow.json`, inspecting nodes, and chatting with the RAG backend.
  - **Step 6**: Suggested next steps (swap documents, turn CLI into an HTTP API, add more advanced n8n agents/tools).

---

## Rationale

- The original workflow included a self-building agent and Google Calendar tooling, which are powerful but can be overwhelming for someone who is just trying to learn how to:
  - Build a simple RAG pipeline, and
  - Connect it to n8n for an interactive chat experience.
- By simplifying the workflow and introducing a JSON-based CLI, the integration between n8n and the Python backend becomes much easier to reason about and to teach.
- The new `LIGHTNING_PATH.md` provides a concrete, time-boxed path that can be followed in a workshop or self-study setting.

---

## How to test

1. **Backend**
   - Ensure you have an `OPENAI_API_KEY` set in `.env`.
   - From the project root, run:
     - `python create_database.py`
     - `python rag_cli.py "How does Alice meet the Mad Hatter?"`
   - Confirm that `rag_cli.py` prints a JSON object with `answer` and `sources`.

2. **n8n workflow**
   - Start n8n locally:
     - `npx n8n`
   - In the n8n UI:
     - Import `n8n_workflow.json`.
     - Execute/activate the workflow.
     - Open the chat panel, say "hi", and then ask a question about Alice in Wonderland.
   - You should see a grounded answer along with a small list of source files.

---

## Notes for reviewers

- This PR is intentionally focused on being **teachable** and **beginner-friendly** rather than feature-rich.
- All changes in this PR were generated and organized by an AI assistant (GPT-5.1) under the direction of the repository owner.
- Please feel free to adjust wording, naming, or node positions to better match your teaching style or visual preferences in n8n.